### PR TITLE
Release v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ func main() {
                 log.Printf("<%s> %d %d '%s'", r.RemoteAddress, r.Length, length, string(r.Data))
             }
         },
-        ErrorHandler: func(err error) error {
+        ErrorHandler: func(err error) {
             log.Printf("%s", err)
             return nil
         },
@@ -57,7 +57,6 @@ func main() {
     server := udpsrv.Server{
         Listeners:       []*udpsrv.Listener{&listener},
         Queue:           queue,
-        ErrorHandler:    func(err error) { panic(err) },
         ShutdownTimeout: 10 * time.Second,
     }
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ func main() {
         },
         ErrorHandler: func(err error) {
             log.Printf("%s", err)
-            return nil
         },
     }
 
@@ -57,7 +56,6 @@ func main() {
     server := udpsrv.Server{
         Listeners:       []*udpsrv.Listener{&listener},
         Queue:           queue,
-        ShutdownTimeout: 10 * time.Second,
     }
 
     signals := make(chan os.Signal, 1)

--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ import (
 )
 
 func main() {
-    queue := udpsrv.NewStdQueue(256, runtime.NumCPU(), 100*time.Millisecond)
+    server := udpsrv.NewServer(udpsrv.NewBasicQueue(16))
 
     listener := udpsrv.Listener{
-        Address:       "127.0.0.1:49000",
-        InitialHandler: func(b udpsrv.Bundle) { queue.Enqueue(b) },
-        PacketHandler: func(r udpsrv.Responder, p *udpsrv.Packet) {
+        Address:        "127.0.0.1:49000",
+        BufferSize:     1024,
+        InitialHandler: func(b udpsrv.Bundle) { server.Queue.Enqueue(b) },
+        ErrorHandler:   func(err error) { log.Printf("%s", err) },
+        PacketHandler:  func(r udpsrv.Responder, p *udpsrv.Packet) {
             length, err := r.Write(r.Data)
             if err != nil {
                 log.Printf("<%s> %d %d '%s' %s", p.RemoteAddress, p.Length, length, string(p.Data), err)
@@ -46,17 +48,9 @@ func main() {
                 log.Printf("<%s> %d %d '%s'", p.RemoteAddress, p.Length, length, string(p.Data))
             }
         },
-        ErrorHandler: func(err error) {
-            log.Printf("%s", err)
-        },
     }
-
+    server.Listeners = append(server.Listeners, listener)
     log.Printf("listener setup on: %s", listener.Address)
-
-    server := udpsrv.Server{
-        Listeners:       []*udpsrv.Listener{&listener},
-        Queue:           queue,
-    }
 
     signals := make(chan os.Signal, 1)
     signal.Notify(signals, os.Interrupt, os.Kill)
@@ -110,3 +104,6 @@ $ ./client  "Hello, Four!"
 $ ./client  "Hello, Five!" 
 2022/08/07 16:06:18 (12) Hello, Five!
 ```
+
+## LICENSE
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ func main() {
 
     listener := udpsrv.Listener{
         Address:       "127.0.0.1:49000",
-        PacketHandler: func(b udpsrv.Bundle) { queue.Enqueue(b) },
-        RequestHandler: func(w udpsrv.ResponseWriter, r *udpsrv.Request) {
-            length, err := w.Write(r.Data)
+        InitialHandler: func(b udpsrv.Bundle) { queue.Enqueue(b) },
+        PacketHandler: func(r udpsrv.Responder, p *udpsrv.Packet) {
+            length, err := r.Write(r.Data)
             if err != nil {
-                log.Printf("<%s> %d %d '%s' %s", r.RemoteAddress, r.Length, length, string(r.Data), err)
+                log.Printf("<%s> %d %d '%s' %s", p.RemoteAddress, p.Length, length, string(p.Data), err)
             } else {
-                log.Printf("<%s> %d %d '%s'", r.RemoteAddress, r.Length, length, string(r.Data))
+                log.Printf("<%s> %d %d '%s'", p.RemoteAddress, p.Length, length, string(p.Data))
             }
         },
         ErrorHandler: func(err error) {
@@ -61,18 +61,16 @@ func main() {
     signals := make(chan os.Signal, 1)
     signal.Notify(signals, os.Interrupt, os.Kill)
     go func() {
-        server.Shutdown(fmt.Errorf("os signal received: %s", <-signals))
+        server.Halt(fmt.Errorf("os signal received: %s", <-signals), true, 10 * time.Second)
     }()
 
     log.Printf("starting server")
-    
     if err := server.Listen(); err != nil {
         log.Printf("error during setup: %s", err)
         os.Exit(1)
     }
 
     log.Printf("stopping server: %s", <-server.Done)
-
     if err := <-server.Done; err != nil {
         log.Printf("error during stop: %s", err)
         os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/naeimc/udpsrv
 
-go 1.18
+go 1.19

--- a/listener.go
+++ b/listener.go
@@ -23,9 +23,7 @@ type Listener struct {
 	RequestHandler func(ResponseWriter, *Request)
 
 	// The ErrorHandler processes any errors returned by net.PacketConn.ReadFrom().
-	// Errors returned by the ErrorHandler cause the server to panic.
-	// If nil all errors are passed to the server.
-	ErrorHandler func(error) error
+	ErrorHandler func(error)
 
 	// The size of the data buffer used by the client.
 	// If <= 0 the BufferSize is set to the the maximum size of a udp payload (65527).
@@ -52,7 +50,7 @@ func (l *Listener) setup(queue Queue) error {
 	}
 
 	if l.ErrorHandler == nil {
-		l.ErrorHandler = func(err error) error { return err }
+		l.ErrorHandler = func(err error) {}
 	}
 
 	if l.BufferSize <= 0 {

--- a/listener.go
+++ b/listener.go
@@ -49,12 +49,12 @@ func (l *Listener) setup(queue Queue) error {
 	}
 	l.Connection = connection
 
-	if l.PacketHandler == nil {
-		l.InitialHandler = func(b Bundle) { queue.Enqueue(b) }
+	if l.InitialHandler == nil {
+		return ErrNoInitialHandler{}
 	}
 
-	if l.ErrorHandler == nil {
-		l.ErrorHandler = func(err error) {}
+	if l.PacketHandler == nil {
+		return ErrNoPacketHandler{}
 	}
 
 	if l.BufferSize <= 0 {
@@ -90,4 +90,16 @@ func (l *Listener) run() {
 func (l *Listener) halt() error {
 	l.halted = true
 	return l.Connection.Close()
+}
+
+type ErrNoInitialHandler struct{}
+
+func (e ErrNoInitialHandler) Error() string {
+	return "no initial handler set"
+}
+
+type ErrNoPacketHandler struct{}
+
+func (e ErrNoPacketHandler) Error() string {
+	return "no packet handler set"
 }

--- a/queue.go
+++ b/queue.go
@@ -2,7 +2,6 @@ package udpsrv
 
 import (
 	"sync"
-	"time"
 )
 
 // A Queue is responsible for handling the transfer of bundles between listeners and servers
@@ -17,66 +16,36 @@ type Queue interface {
 	Wait()           // Wait for the wait group.
 }
 
-// A StdQueue provides a bufferable queue as well as an optional rate limiter and an optional worker limiter.
-type StdQueue struct {
+// A BasicQueue provides a bufferable queue and a waitgroup.
+type BasicQueue struct {
 	C         chan Bundle
 	WaitGroup *sync.WaitGroup
-	Ticker    *time.Ticker
-	Limit     int
-	Current   int
 }
 
-func NewStdQueue(capacity, workerLimit int, rateLimit time.Duration) *StdQueue {
-
-	var ticker *time.Ticker
-	if rateLimit != 0 {
-		ticker = time.NewTicker(rateLimit)
-	}
-
-	return &StdQueue{
+func NewBasicQueue(capacity int) *BasicQueue {
+	return &BasicQueue{
 		C:         make(chan Bundle, capacity),
 		WaitGroup: new(sync.WaitGroup),
-		Ticker:    ticker,
-		Limit:     workerLimit,
 	}
 }
 
-func (q StdQueue) Ready() bool {
-	if len(q.C) == 0 {
-		return false
-	}
-
-	if (q.Limit != 0) && (q.Current >= q.Limit) {
-		return false
-	}
-
-	if (q.Ticker != nil) && (len(q.Ticker.C) == 0) {
-		return false
-	}
-
-	return true
+func (q BasicQueue) Ready() bool {
+	return len(q.C) > 0
 }
 
-func (q StdQueue) Enqueue(b Bundle) {
+func (q BasicQueue) Enqueue(b Bundle) {
 	q.C <- b
 }
 
-func (q *StdQueue) Dequeue() Bundle {
+func (q BasicQueue) Dequeue() Bundle {
 	q.WaitGroup.Add(1)
-	q.Current++
-
-	if q.Ticker != nil {
-		<-q.Ticker.C
-	}
-
 	return <-q.C
 }
 
-func (q *StdQueue) Notify() {
+func (q BasicQueue) Notify() {
 	q.WaitGroup.Done()
-	q.Current--
 }
 
-func (q StdQueue) Wait() {
+func (q BasicQueue) Wait() {
 	q.WaitGroup.Wait()
 }

--- a/server.go
+++ b/server.go
@@ -47,7 +47,7 @@ func (s *Server) setup() error {
 	}
 
 	s.haltChannel = make(chan haltMessage, 1)
-	s.Done = make(chan error, 2)
+	s.Done = make(chan error, 2+listenerCount)
 
 	return nil
 }
@@ -69,12 +69,12 @@ func (s *Server) work(b Bundle) {
 	defer s.Queue.Notify()
 
 	if b.Length > 0 {
-		b.RequestHandler(
-			ResponseWriter{
+		b.PacketHandler(
+			Responder{
 				connection: b.Connection,
 				address:    b.RemoteAddress,
 			},
-			&Request{
+			&Packet{
 				Timestamp:     b.Timestamp,
 				LocalAddress:  b.LocalAddress,
 				RemoteAddress: b.RemoteAddress,

--- a/server.go
+++ b/server.go
@@ -5,11 +5,12 @@ import (
 )
 
 type Server struct {
-	// All the listeners used by the server.
-	Listeners []*Listener
 
 	// The Queue on which server receives bundles of data from the listeners.
 	Queue Queue
+
+	// All the listeners used by the server.
+	Listeners []*Listener
 
 	// The Done channel is channel (of min size 2) that returns the reason for the server shutdown
 	// an error if the server times out during shutdown and any errors when closing the connection.
@@ -17,6 +18,13 @@ type Server struct {
 
 	stopped     bool
 	haltChannel chan haltMessage
+}
+
+func NewServer(queue Queue) *Server {
+	return &Server{
+		Queue:     queue,
+		Listeners: make([]*Listener, 0),
+	}
 }
 
 // Starts the server.

--- a/server.go
+++ b/server.go
@@ -11,15 +11,12 @@ type Server struct {
 	// The Queue on which server receives bundles of data from the listeners.
 	Queue Queue
 
-	// How long to wait for workers to complete before forcing a shutdown.
-	// If 0 the server waits forever.
-	ShutdownTimeout time.Duration
-
-	// The Done channel is channel (of size 2) that returns both the reason for the server shutdown
-	// and an error if the server times out during shutdown.
+	// The Done channel is channel (of min size 2) that returns the reason for the server shutdown
+	// an error if the server times out during shutdown and any errors when closing the connection.
 	Done chan error
 
-	stopped bool
+	stopped     bool
+	haltChannel chan haltMessage
 }
 
 // Starts the server.
@@ -31,15 +28,8 @@ func (s *Server) Listen() error {
 	return nil
 }
 
-// Closes the server while waiting for the workers to complete
-// or a timeout to occur.
-func (s *Server) Shutdown(reason error) {
-	s.halt(reason, true)
-}
-
-// Closes the server wihout waiting for the workers to complete.
-func (s *Server) Close(reason error) {
-	s.halt(reason, false)
+func (s *Server) Halt(reason error, wait bool, timeout time.Duration) {
+	s.haltChannel <- haltMessage{reason, wait, timeout}
 }
 
 func (s *Server) setup() error {
@@ -47,13 +37,16 @@ func (s *Server) setup() error {
 		return ErrNoQueueAllocated{}
 	}
 
+	var listenerCount int
 	for _, listener := range s.Listeners {
 		if err := listener.setup(s.Queue); err != nil {
 			return err
 		}
 		go listener.run()
+		listenerCount++
 	}
 
+	s.haltChannel = make(chan haltMessage, 1)
 	s.Done = make(chan error, 2)
 
 	return nil
@@ -61,14 +54,18 @@ func (s *Server) setup() error {
 
 func (s *Server) run() {
 	for !s.stopped {
-		if s.Queue.Ready() {
-			go s.work(s.Queue.Dequeue())
+		select {
+		case h := <-s.haltChannel:
+			s.halt(h)
+		default:
+			if s.Queue.Ready() {
+				go s.work(s.Queue.Dequeue())
+			}
 		}
 	}
 }
 
 func (s *Server) work(b Bundle) {
-
 	defer s.Queue.Notify()
 
 	if b.Length > 0 {
@@ -92,16 +89,16 @@ func (s *Server) work(b Bundle) {
 	}
 }
 
-func (s *Server) halt(reason error, waitingForWorkers bool) {
+func (s *Server) halt(h haltMessage) {
 	s.stopped = true
 
+	listenerErrors := make([]error, 0)
 	for _, listener := range s.Listeners {
-		listener.Connection.Close()
+		listenerErrors = append(listenerErrors, listener.halt())
 	}
 
-	var err error
-
-	if waitingForWorkers {
+	var haltError error
+	if h.wait {
 		wait := make(chan bool, 1)
 		go func() {
 			s.Queue.Wait()
@@ -109,22 +106,31 @@ func (s *Server) halt(reason error, waitingForWorkers bool) {
 		}()
 
 		timeout := make(chan time.Time, 1)
-		if s.ShutdownTimeout > 0 {
+		if h.timeout > 0 {
 			go func() {
-				timeout <- <-time.NewTicker(s.ShutdownTimeout).C
+				timeout <- <-time.NewTicker(h.timeout).C
 			}()
 		}
 
 		select {
 		case <-timeout:
-			err = ErrShutdownTimedOut{}
+			haltError = ErrShutdownTimedOut{}
 		case <-wait:
 		}
 	}
 
-	s.Done <- reason
-	s.Done <- err
+	s.Done <- h.reason
+	s.Done <- haltError
+	for _, listenerError := range listenerErrors {
+		s.Done <- listenerError
+	}
 	close(s.Done)
+}
+
+type haltMessage struct {
+	reason  error
+	wait    bool
+	timeout time.Duration
 }
 
 type ErrShutdownTimedOut struct{}

--- a/server.go
+++ b/server.go
@@ -11,11 +11,6 @@ type Server struct {
 	// The Queue on which server receives bundles of data from the listeners.
 	Queue Queue
 
-	// The error handler used by the server.
-	// Any errors passed to the server will be handled by this error handler.
-	// If nil the error handler will panic on any error received.
-	ErrorHandler func(error)
-
 	// How long to wait for workers to complete before forcing a shutdown.
 	// If 0 the server waits forever.
 	ShutdownTimeout time.Duration
@@ -50,10 +45,6 @@ func (s *Server) Close(reason error) {
 func (s *Server) setup() error {
 	if s.Queue == nil {
 		return ErrNoQueueAllocated{}
-	}
-
-	if s.ErrorHandler == nil {
-		s.ErrorHandler = func(err error) { panic(err) }
 	}
 
 	for _, listener := range s.Listeners {
@@ -97,9 +88,7 @@ func (s *Server) work(b Bundle) {
 	}
 
 	if b.Error != nil {
-		if err := b.ErrorHandler(b.Error); err != nil {
-			s.ErrorHandler(err)
-		}
+		b.ErrorHandler(b.Error)
 	}
 }
 

--- a/udpsrv.go
+++ b/udpsrv.go
@@ -38,7 +38,7 @@ type Bundle struct {
 	Timestamp      time.Time
 	Connection     net.PacketConn
 	RequestHandler func(ResponseWriter, *Request)
-	ErrorHandler   func(error) error
+	ErrorHandler   func(error)
 	Length         int
 	LocalAddress   net.Addr
 	RemoteAddress  net.Addr

--- a/udpsrv.go
+++ b/udpsrv.go
@@ -12,7 +12,7 @@ const (
 )
 
 // Data received from the client.
-type Request struct {
+type Packet struct {
 	Timestamp     time.Time
 	LocalAddress  net.Addr
 	RemoteAddress net.Addr
@@ -20,14 +20,14 @@ type Request struct {
 	Data          []byte
 }
 
-// A Writer that can be used to respond to the client.
-type ResponseWriter struct {
+// A writer that can be used to respond to the client.
+type Responder struct {
 	connection net.PacketConn
 	address    net.Addr
 }
 
 // Writes data to the client.
-func (w ResponseWriter) Write(p []byte) (int, error) {
+func (w Responder) Write(p []byte) (int, error) {
 	return w.connection.WriteTo(p, w.address)
 }
 
@@ -35,13 +35,13 @@ func (w ResponseWriter) Write(p []byte) (int, error) {
 // As well as a timestamp, the connection, and the RequestHandler and ErrorHandler of the listener.
 // This data is passed to the server to construct the Request and ResponseWriter.
 type Bundle struct {
-	Timestamp      time.Time
-	Connection     net.PacketConn
-	RequestHandler func(ResponseWriter, *Request)
-	ErrorHandler   func(error)
-	Length         int
-	LocalAddress   net.Addr
-	RemoteAddress  net.Addr
-	Data           []byte
-	Error          error
+	Timestamp     time.Time
+	Connection    net.PacketConn
+	PacketHandler func(Responder, *Packet)
+	ErrorHandler  func(error)
+	LocalAddress  net.Addr
+	RemoteAddress net.Addr
+	Length        int
+	Data          []byte
+	Error         error
 }

--- a/udpsrv_test.go
+++ b/udpsrv_test.go
@@ -7,11 +7,7 @@ import (
 )
 
 func Example() {
-
-	server := Server{
-		Listeners: make([]*Listener, 0),
-		Queue:     NewBasicQueue(2),
-	}
+	server := NewServer(NewBasicQueue(16))
 
 	listener := &Listener{
 		Address:        "127.0.0.1:49000",
@@ -20,7 +16,6 @@ func Example() {
 		PacketHandler:  func(r Responder, p *Packet) { fmt.Printf("(%d) %s\n", p.Length, string(p.Data)) },
 		ErrorHandler:   func(err error) { fmt.Printf("%s", err) },
 	}
-
 	server.Listeners = append(server.Listeners, listener)
 
 	go func() {

--- a/udpsrv_test.go
+++ b/udpsrv_test.go
@@ -14,8 +14,8 @@ func Example() {
 	listener := &Listener{
 		Address:        "127.0.0.1:49000",
 		BufferSize:     1024,
-		PacketHandler:  func(b Bundle) { queue.Enqueue(b) },
-		RequestHandler: func(w ResponseWriter, r *Request) { fmt.Printf("(%d) %s\n", r.Length, string(r.Data)) },
+		InitialHandler: func(b Bundle) { queue.Enqueue(b) },
+		PacketHandler:  func(r Responder, p *Packet) { fmt.Printf("(%d) %s\n", p.Length, string(p.Data)) },
 		ErrorHandler:   func(err error) { fmt.Printf("%s", err) },
 	}
 
@@ -43,15 +43,14 @@ func Example() {
 		time.Sleep(2 * time.Second)
 		connection.Write([]byte("Hello, Two!"))
 	}()
-
 	fmt.Printf("listener setup on %s\n", server.Listeners[0].Address)
-	fmt.Printf("starting server\n")
 
+	fmt.Printf("starting server\n")
 	if err := server.Listen(); err != nil {
 		panic(err)
 	}
-	fmt.Printf("stopping server: %s\n", <-server.Done)
 
+	fmt.Printf("stopping server: %s\n", <-server.Done)
 	if err := <-server.Done; err != nil {
 		fmt.Printf("timeout error: %s\n", <-server.Done)
 	} else {

--- a/udpsrv_test.go
+++ b/udpsrv_test.go
@@ -3,26 +3,25 @@ package udpsrv
 import (
 	"fmt"
 	"net"
-	"runtime"
 	"time"
 )
 
 func Example() {
 
-	queue := NewStdQueue(16, runtime.NumCPU(), time.Second)
+	server := Server{
+		Listeners: make([]*Listener, 0),
+		Queue:     NewBasicQueue(2),
+	}
 
 	listener := &Listener{
 		Address:        "127.0.0.1:49000",
 		BufferSize:     1024,
-		InitialHandler: func(b Bundle) { queue.Enqueue(b) },
+		InitialHandler: func(b Bundle) { server.Queue.Enqueue(b) },
 		PacketHandler:  func(r Responder, p *Packet) { fmt.Printf("(%d) %s\n", p.Length, string(p.Data)) },
 		ErrorHandler:   func(err error) { fmt.Printf("%s", err) },
 	}
 
-	server := Server{
-		Listeners: []*Listener{listener},
-		Queue:     queue,
-	}
+	server.Listeners = append(server.Listeners, listener)
 
 	go func() {
 		time.Sleep(8 * time.Second)

--- a/udpsrv_test.go
+++ b/udpsrv_test.go
@@ -13,21 +13,20 @@ func Example() {
 
 	listener := &Listener{
 		Address:        "127.0.0.1:49000",
+		BufferSize:     1024,
 		PacketHandler:  func(b Bundle) { queue.Enqueue(b) },
 		RequestHandler: func(w ResponseWriter, r *Request) { fmt.Printf("(%d) %s\n", r.Length, string(r.Data)) },
 		ErrorHandler:   func(err error) { fmt.Printf("%s", err) },
-		BufferSize:     1024,
 	}
 
 	server := Server{
-		Listeners:       []*Listener{listener},
-		Queue:           queue,
-		ShutdownTimeout: 10 * time.Second,
+		Listeners: []*Listener{listener},
+		Queue:     queue,
 	}
 
 	go func() {
 		time.Sleep(8 * time.Second)
-		server.Shutdown(fmt.Errorf("requested by user"))
+		server.Halt(fmt.Errorf("requested by user"), true, 10*time.Second)
 	}()
 
 	// simulate client

--- a/udpsrv_test.go
+++ b/udpsrv_test.go
@@ -15,17 +15,13 @@ func Example() {
 		Address:        "127.0.0.1:49000",
 		PacketHandler:  func(b Bundle) { queue.Enqueue(b) },
 		RequestHandler: func(w ResponseWriter, r *Request) { fmt.Printf("(%d) %s\n", r.Length, string(r.Data)) },
-		ErrorHandler: func(err error) error {
-			fmt.Printf("%s", err)
-			return nil
-		},
-		BufferSize: 1024,
+		ErrorHandler:   func(err error) { fmt.Printf("%s", err) },
+		BufferSize:     1024,
 	}
 
 	server := Server{
 		Listeners:       []*Listener{listener},
 		Queue:           queue,
-		ErrorHandler:    func(err error) { panic(err) },
 		ShutdownTimeout: 10 * time.Second,
 	}
 


### PR DESCRIPTION
- Replaced Shutdown & Close with Halt
- Removed server error handler
- Halt uses channel
- Let Listener auto handle connection close.
- Add NewServer()
- Renamed Handlers
- Renamed Request and ResponseWriter
- Listener Error Handler no longer requires return
- Simplified Queue
- Remove Listener and Server Defaults